### PR TITLE
modify: Deleted zero check to performance up.

### DIFF
--- a/lib/rsa/accumulator.rb
+++ b/lib/rsa/accumulator.rb
@@ -61,7 +61,7 @@ module RSA
       if hold_elements
         elements.each do |e|
           p = hash_to_prime(e)
-          self.products *= p unless products.modulo(p) == 0
+          self.products *= p
         end
       end
       RSA::ACC::MembershipProof.new(elements, current_acc, value, RSA::ACC::PoE.prove(current_acc, p, value, n))


### PR DESCRIPTION
Because it is low probability enough to ignore.

# The Performance report:
## before:
```
100 times report.
                                     user     system      total        real
batch add to hold_acc            6.213945   0.189028   6.402973 ( 16.214209)
add each element to hold_acc    10.714251   0.312159  11.026410 ( 29.714216)
batch add                        3.741399   0.110403   3.851802 (  8.955274)
add each element                 7.848943   0.222264   8.071207 ( 23.272001)

1,000 times report.
                                     user     system      total        real
batch add to hold_acc           50.194616   0.742001  50.936617 ( 74.493594)
add each element to hold_acc    83.209840   1.123234  84.333074 (123.452611)
batch add                       28.801695   0.411769  29.213464 ( 42.239426)
add each element                57.937197   0.784507  58.721704 ( 94.918167)
```
## after:
```
100 times report.
                                     user     system      total        real
batch add to hold_acc            5.089887   0.082084   5.171971 (  8.331885)
add each element to hold_acc     7.004962   0.109007   7.113969 ( 11.061945)
batch add                        2.125886   0.016057   2.141943 (  2.279057)
add each element                 3.723878   0.023344   3.747222 (  3.935163)

1,000 times report.
                                     user     system      total        real
batch add to hold_acc           46.974971   0.449446  47.424417 ( 52.823945)
add each element to hold_acc    69.161680   0.577233  69.738913 ( 76.756177)
batch add                       25.742260   0.248418  25.990678 ( 30.732190)
add each element                47.438945   0.421949  47.860894 ( 54.146986)
```