### PR TITLE
modify: Delete duplicate processing.

### DIFF
--- a/lib/rsa/accumulator.rb
+++ b/lib/rsa/accumulator.rb
@@ -59,10 +59,7 @@ module RSA
       p = elements_to_prime(elements)
       self.value = value.pow(p, n)
       if hold_elements
-        elements.each do |e|
-          p = hash_to_prime(e)
-          self.products *= p
-        end
+        self.products *= p
       end
       RSA::ACC::MembershipProof.new(elements, current_acc, value, RSA::ACC::PoE.prove(current_acc, p, value, n))
     end

--- a/lib/rsa/accumulator.rb
+++ b/lib/rsa/accumulator.rb
@@ -58,9 +58,7 @@ module RSA
       current_acc = value
       p = elements_to_prime(elements)
       self.value = value.pow(p, n)
-      if hold_elements
-        self.products *= p
-      end
+      self.products *= p if hold_elements
       RSA::ACC::MembershipProof.new(elements, current_acc, value, RSA::ACC::PoE.prove(current_acc, p, value, n))
     end
 


### PR DESCRIPTION
Reason why, the code that make the products(total multiplication) is re-calculate the products that consist prime the couple of hash.